### PR TITLE
Trying to avoid NotSerializableException failing an otherwise successful build

### DIFF
--- a/vars/xwikiBuild.groovy
+++ b/vars/xwikiBuild.groovy
@@ -385,6 +385,8 @@ def attachScreenshotToFailingTests()
 
     // Go through each failed test in the current build.
     def failedTests = testResults.getFailedTests()
+    // Clear potentially problematic non-serializable object reference.
+    testResults = null
     for (def failedTest : failedTests) {
         // Compute the test's screenshot file name.
         def testClass = failedTest.getClassName()
@@ -436,6 +438,8 @@ def attachScreenshotToFailingTests()
 
             // Set the description to the failing test and save it to disk.
             testResultAction.setDescription(failedTest, description)
+            // Clear potentially problematic non-serializable object reference.
+            testResultAction = null
             currentBuild.rawBuild.save()
         }
     }
@@ -526,6 +530,8 @@ def checkForFlickers()
     if (testResultAction != null) {
         // Find all failed tests
         def failedTests = testResultAction.getResult().getFailedTests()
+        // Clear potentially problematic non-serializable object reference.
+        testResultAction = null
         if (failedTests.size() > 0) {
             def knownFlickers = getKnownFlickeringTests()
 


### PR DESCRIPTION
* Caused: java.io.NotSerializableException: hudson.tasks.junit.TestResultAction
* Details at https://github.com/jenkinsci/pipeline-plugin/blob/master/TUTORIAL.md#serializing-local-variables