### PR TITLE
[Misc] Ensure to deploy by default on branch main

### DIFF
--- a/vars/xwikiBuild.groovy
+++ b/vars/xwikiBuild.groovy
@@ -335,11 +335,11 @@ private def computeMavenGoals(config)
 {
     def goals = config.goals
     if (!goals) {
-        // Use "deploy" goal for "master" and "stable-*" branches only and "install" for the rest.
+        // Use "deploy" goal for "master", "main" and "stable-*" branches only and "install" for the rest.
         // This is to avoid having branches with the same version polluting the maven snapshot repo, overwriting one
         // another.
         def branchName = env['BRANCH_NAME']
-        if (branchName != null && (branchName.equals("master") || branchName.startsWith('stable-'))) {
+        if (branchName != null && (branchName.equals("master") || (branchName.equals("main") || branchName.startsWith('stable-'))) {
             goals = "deploy"
         } else {
             goals = "install"

--- a/vars/xwikiBuild.groovy
+++ b/vars/xwikiBuild.groovy
@@ -337,7 +337,8 @@ private def computeMavenGoals(config)
     if (!goals) {
         // Use "deploy" goal for "master", "main" and "stable-*" branches only and "install" for the rest.
         // This is to avoid having branches with the same version polluting the maven snapshot repo, overwriting one
-        // another.
+        // another. We support both "master" and "main" branch names since Github changed the name of the default branch
+        // we now need to support the old name "master" and the new default name "main". 
         def branchName = env['BRANCH_NAME']
         if (branchName != null && (branchName.equals("master") || (branchName.equals("main") || branchName.startsWith('stable-'))) {
             goals = "deploy"

--- a/vars/xwikiBuild.groovy
+++ b/vars/xwikiBuild.groovy
@@ -337,8 +337,8 @@ private def computeMavenGoals(config)
     if (!goals) {
         // Use "deploy" goal for "master", "main" and "stable-*" branches only and "install" for the rest.
         // This is to avoid having branches with the same version polluting the maven snapshot repo, overwriting one
-        // another. We support both "master" and "main" branch names since Github changed the name of the default branch
-        // we now need to support the old name "master" and the new default name "main". 
+        // another. We support both "master" and "main" because GitHub has changed the default branch name from "master" 
+        // to "main" and we need to support both old repos (created with "master") and new ones (created with "main").
         def branchName = env['BRANCH_NAME']
         if (branchName != null && (branchName.equals("master") || (branchName.equals("main") || branchName.startsWith('stable-'))) {
             goals = "deploy"


### PR DESCRIPTION
Github default name for the main branche is no longer "master" but is now "main", so we need to also check for branch named "main" to use deploy by default.