### PR TITLE
[Misc] Limit docker prune to entities older than 30 days

### DIFF
--- a/vars/xwikiBuild.groovy
+++ b/vars/xwikiBuild.groovy
@@ -143,10 +143,13 @@ void call(name = 'Default', body)
         def dockerHubUserId = config.dockerHubUserId ?: 'xwikici'
         generateDockerConfig(dockerHubSecretId, dockerHubUserId)
 
-        // Force removal of unused docker containers, networks, dangling images, volumes to avoid Docker taking more and
-        // more space over time due to leftovers (e.g. https://github.com/testcontainers/testcontainers-java/issues/5667
+        // Force removal of unused docker containers, networks, dangling images older than 30 days (720h), and all
+        // unused volumes (volumes don't support age filtering) to avoid Docker taking more and more space over time due
+        // to leftovers (e.g. https://github.com/testcontainers/testcontainers-java/issues/5667
         // and https://github.com/testcontainers/testcontainers-java/issues/3558)
-        sh script: 'docker system prune --volumes -f', returnStatus: true
+        // Note: --volumes and --filter "until=..." are mutually exclusive in "docker system prune", hence 2 commands.
+        sh script: 'docker system prune -f --filter "until=720h"', returnStatus: true
+        sh script: 'docker volume prune -f', returnStatus: true
 
         // Display some environmental information that can be useful to debug some failures
         // Note: if the executables don't exist, this won't fail the step thanks to "returnStatus: true".


### PR DESCRIPTION
Instead of pruning everything all the time, only prune 'entities' older than 30 days:
- networks and containers might still accumulate, but older entities will still be cleaned up over time.
- more recent entities are not removed and can be accessed locally without needless full re-download
- volumes are always cleared as age is not supported by docker for this type of entities