### PR TITLE
[Misc] Sonar requires Java 17, not Java 11

### DIFF
--- a/vars/configureJavaTool.groovy
+++ b/vars/configureJavaTool.groovy
@@ -31,17 +31,18 @@ def call(config)
         echoXWiki "Value of the xwiki.java.version property: ${javaVersion}"
         if (javaVersion.isNumber()) {
             // A Java version is explicitly indicated in the effective pom
-            if (config.sonar && javaVersion.toInteger() < 11) {
-                // Sonar Maven plugin requires at least Java 11
-                echoXWiki "The Sonar Maven plugin requires at least Java 11 so using it instead of the indicated version [${javaVersion}]"
-                javaVersion = '11'
+            if (config.sonar && javaVersion.toInteger() < 17) {
+                // The scanner engine that the Sonar Maven plugin downloads from SonarCloud is compiled for Java 17,
+                // so the whole build needs to run on Java 17+ even when the code targets an older version.
+                echoXWiki "Sonar requires at least Java 17 so using it instead of version [${javaVersion}]"
+                javaVersion = '17'
             }
             javaTool = "java${javaVersion}"
         } else {
             // If no java version is indicated in the effective pom, try to deduce it from the parent version
             if (config.sonar) {
-                // Sonar requires Java 11+, let's use that.
-                javaTool = '11'
+                // Sonar requires Java 17+ and the "official" Java version we use is now >= Java 17, so use that.
+                javaTool = 'official'
             } else {
                 def pom = readMavenPom file: pomFile
                 javaTool = getJavaTool(pom)


### PR DESCRIPTION
Restores the Java 17 requirement for Sonar builds, reverting the threshold introduced in 00b549c.

# Problem

Since 00b549c, `xwikiBuild` picks Java 11 for a `sonar = true` build whose `xwiki.java.version` is 11, and every such build now fails in `sonar:sonar`:

```
[ERROR] Failed to execute goal org.sonarsource.scanner.maven:sonar-maven-plugin:3.9.1.2184:sonar
  ... java.lang.UnsupportedClassVersionError: org/sonar/batch/bootstrapper/EnvironmentInformation
  has been compiled by a more recent version of the Java Runtime (class file version 61.0),
  this version of the Java Runtime only recognizes class file versions up to 55.0
```

`application-antispam` is one of them — see [#214](https://ci.xwiki.org/job/XWiki%20Contrib/job/application-antispam/job/master/214/) and [#215](https://ci.xwiki.org/job/XWiki%20Contrib/job/application-antispam/job/master/215/).

# Cause

The Java 17 constraint does not come from the Sonar Maven plugin, but from the **scanner engine that the plugin downloads from SonarCloud** at analysis time into `~/.sonar/cache` (the log line right before the failure is `[INFO] User cache: /root/.sonar/cache`). That engine is compiled for Java 17.

`org.sonar.batch.bootstrapper.EnvironmentInformation` is not in any artifact of the plugin's class realm: it is absent from `sonar-scanner-api-2.16.2.588.jar`, whose classes are all Java 8 or older. So no plugin version pin can help — the build JVM itself has to be 17+, even though the module targets Java 11.

The A/B is clean: build [#213](https://ci.xwiki.org/job/XWiki%20Contrib/job/application-antispam/job/master/213/) ran the same `application-antispam` revision with the pre-00b549c logic and Sonar succeeded; [#214](https://ci.xwiki.org/job/XWiki%20Contrib/job/application-antispam/job/master/214/) ran that exact same revision with 00b549c and Sonar failed.

# Changes

* Require Java 17 again when `config.sonar` is set, and go back to the `official` tool when the pom declares no Java version.
* Say in the comment *why* 17 is needed, so the threshold isn't lowered again.

# Executed Tests

None — this is Jenkins shared-library Groovy with no test harness in this repo. It restores the exact behaviour that was green up to and including build #213 of `application-antispam`, and the next build of any `sonar = true` job on a Java 11 module will confirm it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
